### PR TITLE
Add /healthz readiness endpoint (suite deploy contract)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ COPY . .
 EXPOSE 8080
 
 # Listen on all interfaces; honor PORT from the host (e.g. Cloud Run, Knative).
-ENTRYPOINT ["sh", "-c", "exec shiny run app.py --host 0.0.0.0 --port ${PORT:-8080}"]
+# asgi:app is the Shiny app plus a /healthz readiness route (see asgi.py); it
+# replaces `shiny run app.py` so the suite deploy contract's probe is served.
+ENTRYPOINT ["sh", "-c", "exec uvicorn asgi:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/asgi.py
+++ b/asgi.py
@@ -1,0 +1,36 @@
+"""ASGI entrypoint: the Shiny Express app plus a /healthz readiness endpoint.
+
+This exists to satisfy the suite-wide deploy contract (which requires every app
+to expose an HTTP readiness probe). See docs/deploy-contract.md in the dms-tools
+deploy repo.
+
+`app.py` is a Shiny Express app, so it has no explicit `App` object to attach a
+route to. `wrap_express_app()` builds that `App` for us. The returned `App` is
+itself the ASGI entrypoint and owns the Shiny lifespan, so we keep it as the
+root application and register one extra route on its internal Starlette router.
+Mounting Shiny under a *separate* parent Starlette app would drop Shiny's
+lifespan (Starlette does not propagate lifespan into mounted sub-apps).
+
+Local dev is unchanged: `shiny run app.py` still works and simply omits
+/healthz. The container launches this module instead: `uvicorn asgi:app`.
+"""
+
+from pathlib import Path
+
+from shiny.express import wrap_express_app
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+app = wrap_express_app(Path(__file__).parent / "app.py")
+
+
+async def healthz(_request):
+    """Readiness probe. 200 once the app is serving; body is unspecified."""
+    return JSONResponse({"status": "ok"})
+
+
+# Insert ahead of Shiny's catch-all Mount("/") so /healthz resolves here and is
+# not swallowed by Shiny's own routing.
+app.starlette_app.router.routes.insert(
+    0, Route("/healthz", healthz, methods=["GET"])
+)

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,0 +1,12 @@
+# Deploy manifest — services this repo exposes to the suite front door.
+# Consumed by dms-tools. Spec: dms-tools/docs/deploy-contract.md
+services:
+  - name: dimple-qc
+    build:
+      dockerfile: Dockerfile        # builds from this repo's context
+    default_port: 8080              # process binds $PORT, defaults here
+    health:
+      type: http
+      path: /healthz               # served by asgi.py; 200 once Shiny is up
+    resources:
+      memory: 1g                    # advisory: pandas/scipy/biopython/plotly stack


### PR DESCRIPTION
Conforms dimple-qc to the suite deploy contract by exposing an HTTP readiness probe.

## What
- `asgi.py` (new): wraps the Shiny Express app via `wrap_express_app()`, keeps the Shiny `App` as the ASGI root, and registers `/healthz` on its own router (preserves Shiny's lifespan — mounting under a separate parent app would drop it).
- `Dockerfile`: launch `uvicorn asgi:app` instead of `shiny run app.py`. `shiny run app.py` still works for local dev (just without /healthz).
- `deploy.yaml` (new): declares the service, port 8080, `health: http /healthz`.

## Why
First app to adopt the suite deploy contract (spec lives in dms-tools/docs/deploy-contract.md). Lets the front door report readiness instead of mere liveness.

## Validation
Built the image and ran it: `GET /healthz` -> 200 `{"status":"ok"}`, `GET /` -> 200 (Shiny serving), startup log shows "Application startup complete".