### PR TITLE
Bump idna to 3.18 (uv-synced) — security fix CVE-2026-45409

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -183,9 +183,9 @@ htmltools==0.6.0 \
     #   faicons
     #   shiny
     #   shinychat
-idna==3.11 \
-    --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
-    --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+idna==3.18 \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
+    --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
     # via anyio
 importlib-metadata==8.7.1 \
     --hash=sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb \

--- a/uv.lock
+++ b/uv.lock
@@ -340,11 +340,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrade `idna` 3.11 → **3.18** through `uv.lock`, then regenerate `requirements.txt` from the lock so the uv (dev) and pip/Docker (deploy) install paths stay in lockstep. Transitive dep via `anyio`. `uv` resolved to 3.18 — the latest, newer than the 3.15 in #34.

## Why this matters (security)

idna **3.14** fixed **CVE-2026-45409**: oversized inputs are now rejected up-front to close a quadratic-time blowup that bypassed the earlier CVE-2024-3651 mitigation (ReDoS/DoS-style). We're on **3.11**, which is in the vulnerable range.

## Why not just merge #34

#34 edits `requirements.txt` only, leaving `uv.lock` pinning 3.11 — so `uv run` (local dev) would keep running the **vulnerable** version even after merge; the fix would reach only the Docker/deploy path. This PR bumps the lock too, so both paths get the fix. Supersedes #34.

## Verification

- `uv run pytest tests/` → **75 passed**
- `asgi.py` boots under idna 3.18: `/` → 200, `/healthz` → 200 `{"status":"ok"}`

## Follow-up

- Close #34 as superseded.
- Still recommend a `.github/dependabot.yml` for the `uv` ecosystem so future bumps update `uv.lock` directly — see explanation below.