### PR TITLE
Add Dependabot config for the uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Dependabot configuration.
+# uv.lock is the single source of truth for dependencies (the Docker image and
+# `uv sync` both read it; there is no checked-in requirements.txt). Pinning the
+# `uv` ecosystem makes Dependabot update pyproject.toml / uv.lock directly,
+# instead of editing a derived export and drifting out of sync.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    # Collapse routine minor/patch bumps into one weekly PR to cut review noise.
+    # Major bumps still arrive as individual PRs, and security updates open
+    # immediately regardless of this schedule.
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` pinning Dependabot to the **`uv`** ecosystem, so dependency bumps update `pyproject.toml` / `uv.lock` directly.

## Why

Until now Dependabot ran on GitHub's defaults and edited a derived `requirements.txt` export, leaving `uv.lock` stale — the split-brain that produced #30, #31, and #34 (and the #36 merge conflict). With `requirements.txt` removed (#36), `uv.lock` is the single source of truth; this config keeps Dependabot aligned with it.

## Config

- `package-ecosystem: uv`, weekly schedule (Mondays), max 5 open PRs
- Minor/patch bumps **grouped** into a single weekly PR to cut review noise
- Major bumps still arrive as individual PRs; security updates open immediately regardless of schedule
- `deps` commit-message prefix

Validated as well-formed YAML against the Dependabot v2 schema fields locally.